### PR TITLE
Feat/ add possibility to pass your own database driver to transactional event emitter

### DIFF
--- a/packages/core/src/driver/database.driver-persister.ts
+++ b/packages/core/src/driver/database.driver-persister.ts
@@ -1,0 +1,8 @@
+export interface DatabaseDriverPersister {
+
+  persist<T>(entity: T): void;
+
+  remove<T>(entity: T): void;
+
+  flush(): Promise<void>;
+}

--- a/packages/core/src/driver/database.driver.ts
+++ b/packages/core/src/driver/database.driver.ts
@@ -1,14 +1,13 @@
 import { InboxOutboxTransportEvent } from '../model/inbox-outbox-transport-event.interface';
 
-
 export interface DatabaseDriver {
   createInboxOutboxTransportEvent(eventName: string, eventPayload: any, expireAt: number, readyToRetryAfter: number | null): InboxOutboxTransportEvent;
 
   findAndExtendReadyToRetryEvents(limit: number): Promise<InboxOutboxTransportEvent[]>;
 
-  persist<T>(entity: T): Promise<void>;
+  persist<T>(entity: T): void;
 
-  remove<T>(entity: T): Promise<void>;
+  remove<T>(entity: T): void;
 
   flush(): Promise<void>;
 }

--- a/packages/core/src/driver/database.driver.ts
+++ b/packages/core/src/driver/database.driver.ts
@@ -1,13 +1,7 @@
 import { InboxOutboxTransportEvent } from '../model/inbox-outbox-transport-event.interface';
+import { DatabaseDriverPersister } from './database.driver-persister';
 
-export interface DatabaseDriver {
+export interface DatabaseDriver extends DatabaseDriverPersister {
   createInboxOutboxTransportEvent(eventName: string, eventPayload: any, expireAt: number, readyToRetryAfter: number | null): InboxOutboxTransportEvent;
-
   findAndExtendReadyToRetryEvents(limit: number): Promise<InboxOutboxTransportEvent[]>;
-
-  persist<T>(entity: T): void;
-
-  remove<T>(entity: T): void;
-
-  flush(): Promise<void>;
 }

--- a/packages/core/src/emitter/contract/inbox-outbox-event.interface.ts
+++ b/packages/core/src/emitter/contract/inbox-outbox-event.interface.ts
@@ -1,6 +1,6 @@
 export abstract class InboxOutboxEvent {
   /**
-   * @description Should be unique static name of the event
+   * @description Should be unique name of the event
    */
-  name: string;
+  public abstract readonly name: string;
 }

--- a/packages/core/src/emitter/transactional-event-emitter.ts
+++ b/packages/core/src/emitter/transactional-event-emitter.ts
@@ -44,7 +44,7 @@ export class TransactionalEventEmitter {
 
     const inboxOutboxTransportEvent = databaseDriver.createInboxOutboxTransportEvent(event.name, event, currentTimestamp + eventOptions.listeners.expiresAtTTL, currentTimestamp + eventOptions.listeners.readyToRetryAfterTTL);
 
-    const persister = customDatabaseDriverPersister || databaseDriver;
+    const persister = customDatabaseDriverPersister ?? databaseDriver;
 
     entities.forEach((entity) => {
       if (entity.operation === TransactionalEventEmitterOperations.persist) {


### PR DESCRIPTION
This pull request includes several changes to improve the database driver interface, enhance the event emitter functionality, and update the event interface. The most important changes include modifying the `DatabaseDriver` interface, adding an overloaded `emit` method to the `TransactionalEventEmitter`, and updating the `InboxOutboxEvent` class.

### Enhancements to database driver interface:

* [`packages/core/src/driver/database.driver.ts`](diffhunk://#diff-0e528451c2ff8d10d0745c90726164f36024cfdf756e0c92d05f52f2046d3e0fL3-R10): Changed the `persist` and `remove` methods to be synchronous by removing the `Promise` return type.

### Improvements to event emitter functionality:

* [`packages/core/src/emitter/transactional-event-emitter.ts`](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007R33-R64): Added an overloaded `emit` method that accepts an optional `DatabaseDriver` parameter, allowing the caller to specify a database driver.
* [`packages/core/src/emitter/transactional-event-emitter.ts`](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007R3): Imported the `DatabaseDriver` interface to ensure type safety for the new `emit` method.

### Updates to event interface:

* [`packages/core/src/emitter/contract/inbox-outbox-event.interface.ts`](diffhunk://#diff-ee56b96021971190a147b57e3a5069074519000c01bd0c3e0ecce1f23d3bd962L3-R5): Changed the `name` property to be an abstract readonly property, ensuring that subclasses define a unique name for the event.