### PR TITLE
tweaks to typing

### DIFF
--- a/packages/core/src/driver/database.driver-persister.ts
+++ b/packages/core/src/driver/database.driver-persister.ts
@@ -1,8 +1,7 @@
 export interface DatabaseDriverPersister {
+  persist<T extends object>(entity: T): void;
 
-  persist<T>(entity: T): void;
-
-  remove<T>(entity: T): void;
+  remove<T extends object>(entity: T): void;
 
   flush(): Promise<void>;
 }


### PR DESCRIPTION
This pull request includes several changes to improve type safety and code readability in the `packages/core` module. The most important changes involve updating type definitions and refactoring code for better clarity.

Type safety improvements:

* [`packages/core/src/driver/database.driver-persister.ts`](diffhunk://#diff-b329c876d8b27aa8c6dcc1556fc2cc6bbf7076a7a8c3d56dd5717ae7548a6cfaR2-R4): Updated the `persist` and `remove` methods to use `T extends object` instead of `T` to ensure that only objects can be passed as arguments.

Code readability improvements:

* [`packages/core/src/emitter/transactional-event-emitter.ts`](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007L3-L10): Refactored the import statements to correctly import `DatabaseDriverPersister` and updated the `entities` parameter type in the `emit` method to `object` instead of `any`. [[1]](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007L3-L10) [[2]](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007L32-R31)
* [`packages/core/src/emitter/transactional-event-emitter.ts`](diffhunk://#diff-6138d2b4e62bbf7c0f451e62961df00b0ce19831c9f2750818dd20ccbe0f5007L45-R49): Reformatted the `createInboxOutboxTransportEvent` method call to improve readability by spreading the arguments over multiple lines.